### PR TITLE
Add font gorups

### DIFF
--- a/src/hooks/use-yjs-font-sync.ts
+++ b/src/hooks/use-yjs-font-sync.ts
@@ -36,6 +36,7 @@ export function useYjsFontSync(props: useYjsFontSyncType) {
           family: f.family,
           style: f.style,
           favorite: f.favorite ?? false,
+          styles: [],
         }))
       );
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,18 @@ export const FontMetaSchema = z.object({
   family: z.string(),
   style: z.string(),
   favorite: z.boolean().optional().default(false),
+  styles: z
+    .array(
+      z.object({
+        postscriptName: z.string(),
+        fullName: z.string(),
+        family: z.string(),
+        style: z.string(),
+        favorite: z.boolean().optional().default(false),
+      })
+    )
+    .optional()
+    .default([]),
 });
 export type FontMeta = z.infer<typeof FontMetaSchema>;
 


### PR DESCRIPTION
This pull request refactors the `LocalFontViewer` component to group fonts by family, introduces a new `FontFamilyCard` component for displaying grouped fonts, and updates related data structures and utilities to support these changes. Key updates include moving font grouping logic from the `useLocalFonts` hook to the component, enhancing the `FontMeta` type, and simplifying the UI for better readability and maintainability.

### Component Refactoring and Enhancements:
* Replaced the flat list of fonts with a grouped structure, where fonts are organized by family and their styles are nested. This logic was moved from the `useLocalFonts` hook to the `LocalFontViewer` component using `React.useMemo`. (`src/components/local-font-viewer.tsx`, [src/components/local-font-viewer.tsxL52-R82](diffhunk://#diff-de1e901f5de8baad8e30ca7c992a04684eff6208f2167031e423babc0cb06ce9L52-R82))
* Introduced a new `FontFamilyCard` component to display grouped fonts, including an accordion for toggling additional styles. This replaces the previous `FontMeta` component for rendering individual fonts. (`src/components/local-font-viewer.tsx`, [src/components/local-font-viewer.tsxL122-R263](diffhunk://#diff-de1e901f5de8baad8e30ca7c992a04684eff6208f2167031e423babc0cb06ce9L122-R263))

### Data Structure Updates:
* Updated the `FontMeta` schema to include a `styles` field, which holds an array of nested font styles for each font family. This ensures compatibility with the new grouped structure. (`src/types.ts`, [src/types.tsR17-R28](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR17-R28))
* Modified the `useYjsFontSync` hook to initialize the `styles` field as an empty array for each font. (`src/hooks/use-yjs-font-sync.ts`, [src/hooks/use-yjs-font-sync.tsR39](diffhunk://#diff-f69bd8f333ba58db7893346d3d73198ccfee1659917bc0fabdff39fb6461fa0cR39))

### UI and Styling Improvements:
* Simplified the font preview UI by increasing the font size and removing redundant metadata fields. The new layout focuses on the font's full name and favorite toggle. (`src/components/local-font-viewer.tsx`, [src/components/local-font-viewer.tsxL185-R291](diffhunk://#diff-de1e901f5de8baad8e30ca7c992a04684eff6208f2167031e423babc0cb06ce9L185-R291))
